### PR TITLE
Correction de coquilles

### DIFF
--- a/cours/01-sept-04/02-python.html
+++ b/cours/01-sept-04/02-python.html
@@ -386,7 +386,7 @@ def faire_qqchose(param1, *args, **kwargs):
     print(param1, args, kwargs)
 
 faire_qqchose('foobar', 42, 'hello', cours='web', groupe='20')
-#Affiche 'foobar' [42, 'hellp'] {'cours': 'web', 'groupe'='20'}
+#Affiche 'foobar' [42, 'hello'] {'cours': 'web', 'groupe'='20'}
 </code></pre>
                   </section>
                   <section>

--- a/cours/02-sept-11/03-intro-python-suite.md
+++ b/cours/02-sept-11/03-intro-python-suite.md
@@ -125,7 +125,7 @@ Ou chainer des exceptions
 
 ```python
 ....     except TypeError:
-....        print("La veleur n'est pas un chiffre")
+....        print("La valeur n'est pas un chiffre")
 ....     except ZeroDivisionError:
 ....        print("Impossible de diviser par zéro")
 ```


### PR DESCRIPTION
- `hellp` devrait être `hello` dans 02-python.html
- `veleur` devrait être `valeur` dans 03-intro-python-suite.md`