### PR TITLE
Rouler docker avec usager standard

### DIFF
--- a/cours/09-oct-28/labo/05-labo.md
+++ b/cours/09-oct-28/labo/05-labo.md
@@ -63,13 +63,20 @@ Installez Docker EE avec les instructions suivantes :
 6. Mettez à jour apt
 
 ```
-    $ apt-get update
+    $ sudo apt-get update
 ```
 
 7. Installez Docker CE
 
 ```
     $ sudo apt-get install docker-ce
+```
+
+8. Ajouter l'usager courant dans le groupe docker
+
+```
+    $ sudo usermod -aG docker $USER
+    $ su - $USER
 ```
 
 #### Autre Linux


### PR DESCRIPTION
Pour suivre les instructions du labo et rouler docker avec un usager standard, il faut que cet usager soit dans le groupe docker.