### PR TITLE
Correctif du labo du 22 novembre

### DIFF
--- a/cours/12-nov-20/labo/08-redis.md
+++ b/cours/12-nov-20/labo/08-redis.md
@@ -277,7 +277,7 @@ def show_page():
     job = queue.enqueue(fetch_page, url)
     return redirect(url_for('fetch_page', job_id=job.id))
 
-@app.route("/<string:job_id>")
+@app.route("/job/<string:job_id>")
 def verify_job(job_id):
     return
 ```
@@ -285,7 +285,7 @@ def verify_job(job_id):
 5. Dans le contrôleur `verify_job`, on peut vérifier si job est terminée avec `Job.is_finished`
 
 ```python
-@app.route("/<string:job_id>")
+@app.route("/job/<string:job_id>")
 def verify_job(job_id):
     job = queue.fetch_job(job_id)
     if not job.is_finished:
@@ -295,7 +295,7 @@ def verify_job(job_id):
 6. Une fois que la job est terminée, on peut récupérer le résultat de celle-ci (la page web!)
 
 ```python
-@app.route("/<string:job_id>")
+@app.route("/job/<string:job_id>")
 def verify_job(job_id):
     job = queue.fetch_job(job_id)
     if not job.is_finished:

--- a/cours/12-nov-20/labo/08-redis.md
+++ b/cours/12-nov-20/labo/08-redis.md
@@ -275,7 +275,7 @@ def show_page():
     url = request.form['url']
 
     job = queue.enqueue(fetch_page, url)
-    return redirect(url_for('fetch_page', job_id=job.id))
+    return redirect(url_for('verify_job', job_id=job.id))
 
 @app.route("/job/<string:job_id>")
 def verify_job(job_id):

--- a/cours/12-nov-20/labo/tache.py
+++ b/cours/12-nov-20/labo/tache.py
@@ -27,7 +27,7 @@ def show_page():
     else:
         return page
 
-@app.route("/<string:job_id>")
+@app.route("/job/<string:job_id>")
 def verify_job(job_id):
     job = queue.fetch_job(job_id)
     if not job.is_finished:


### PR DESCRIPTION
Soumission de correctifs du labo du 22 novembre.

1. Correction du nom de la méthode passée au url_for dans l'énoncé au point 4 de la section des tâches en arrière plan.

2. Changement de l'URL des jobs dans la solution. La route /<string:job_id> causait des erreurs de type AttributeError lors lorsque l'application recevait des get sur favicon.ico