### PR TITLE
Correction ennonce

### DIFF
--- a/travail-de-session/enonce.md
+++ b/travail-de-session/enonce.md
@@ -181,7 +181,7 @@ Content-Type: application/json
 ```json
 { "products": [
         { "id": 123, "quantity": 2 },
-        { "id": 321, "quantity": 1 },
+        { "id": 321, "quantity": 1 }
     ]
 }
 ```

--- a/travail-de-session/enonce.md
+++ b/travail-de-session/enonce.md
@@ -333,7 +333,7 @@ Content-Type: application/json
       "email" : "caissy.jean-philippe@uqam.ca",
       "total_price" : 9148,
       "paid": true,
-      "product" : [
+      "products" : [
          {
            "id" : 123,
            "quantity" : 1
@@ -404,7 +404,7 @@ Content-Type: application/json
       },
       "email" : "caissy.jean-philippe@uqam.ca",
       "total_price" : 9148,
-      "product" : [
+      "products" : [
          {
            "id" : 123,
            "quantity" : 1


### PR DESCRIPTION
Le document json qui est donné en exemple dans la section commande (multiples produits) n'est pas valide.

Dans les exemples d'affichage d'une commande, les deux clefs "product" et "products" sont utilisées de manière interchangée. J'harmoniserais partout à "products".

